### PR TITLE
Add CI workflow: just check + just test on push/PR (#14)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Install just
+        uses: extractions/setup-just@v4
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Lint, format, typecheck
+        run: just check
+
+      - name: Unit + integration tests
+        run: just test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
@@ -12,6 +15,7 @@ concurrency:
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` running `just check` + `just test` on push to `main` and on every pull request.
- Caches uv's global cache keyed on `uv.lock` via `astral-sh/setup-uv@v8`.
- Concurrency: cancels superseded in-progress runs on non-main refs.

Closes #14.

## Notes
- Single job rather than split check/test — small project, simpler, fast enough.
- e2e and LLM evals explicitly out of scope per the issue.
- `extractions/setup-just@v4` for the `just` binary.

## Test plan
- [ ] First run on this PR comes up green.
- [ ] Second push to the branch cancels the first run (concurrency check).
- [ ] Cache hit on the second run (look for "Cache restored" in the setup-uv step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)