### PR TITLE
Add /healthz + shared TestClient fixture (#17, #18)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,8 @@ TDD is the default loop.
 - The wire-protocol version (`API_VERSION` in `src/bahai_api/main.py`)
   bumps only on breaking changes. Additive changes ship under the
   current version.
+- Tests take the shared `client` fixture from `tests/conftest.py`
+  rather than constructing `TestClient(app)` themselves.
 
 ## Cost posture
 

--- a/src/bahai_api/main.py
+++ b/src/bahai_api/main.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from fastapi import FastAPI
 from pydantic import BaseModel, Field
 
@@ -30,10 +32,14 @@ class DiscoveryResponse(BaseModel):
 
 
 class HealthResponse(BaseModel):
-    """Liveness probe payload. Lives outside `API_PREFIX` so probes are
-    stable across wire-protocol version bumps."""
+    """Liveness probe payload.
 
-    status: str = Field(description="Liveness status. `ok` when the process is up.")
+    Lives outside `API_PREFIX` so probes are stable across wire-protocol
+    version bumps. Readiness (DB, downstream deps) is a separate concern
+    and will land on `/readyz` once there's something to depend on.
+    """
+
+    status: Literal["ok"] = Field(description="Liveness status. `ok` when the process is up.")
 
 
 app = FastAPI(title="bahai-api", version=__version__)

--- a/src/bahai_api/main.py
+++ b/src/bahai_api/main.py
@@ -29,6 +29,13 @@ class DiscoveryResponse(BaseModel):
     endpoints: dict[str, str] = Field(description="Map from capability name to its base URL path.")
 
 
+class HealthResponse(BaseModel):
+    """Liveness probe payload. Lives outside `API_PREFIX` so probes are
+    stable across wire-protocol version bumps."""
+
+    status: str = Field(description="Liveness status. `ok` when the process is up.")
+
+
 app = FastAPI(title="bahai-api", version=__version__)
 
 
@@ -41,3 +48,8 @@ def discovery() -> DiscoveryResponse:
         capabilities=list(CAPABILITIES),
         endpoints={cap: f"{API_PREFIX}/{cap}" for cap in CAPABILITIES},
     )
+
+
+@app.get("/healthz", response_model=HealthResponse)
+def healthz() -> HealthResponse:
+    return HealthResponse(status="ok")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+from collections.abc import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from bahai_api.main import app
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    with TestClient(app) as test_client:
+        yield test_client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,5 +8,7 @@ from bahai_api.main import app
 
 @pytest.fixture
 def client() -> Iterator[TestClient]:
+    # Function-scope: TestClient is cheap, and a fresh client per test
+    # avoids order-dependent coupling once tests start mutating state.
     with TestClient(app) as test_client:
         yield test_client

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,12 +1,10 @@
 from fastapi.testclient import TestClient
 
 from bahai_api import __version__
-from bahai_api.main import API_PREFIX, API_VERSION, CAPABILITIES, app
-
-client = TestClient(app)
+from bahai_api.main import API_PREFIX, API_VERSION, CAPABILITIES
 
 
-def test_discovery_returns_service_identity() -> None:
+def test_discovery_returns_service_identity(client: TestClient) -> None:
     response = client.get(API_PREFIX)
 
     assert response.status_code == 200
@@ -16,13 +14,13 @@ def test_discovery_returns_service_identity() -> None:
     assert body["api_version"] == API_VERSION
 
 
-def test_discovery_advertises_all_capabilities() -> None:
+def test_discovery_advertises_all_capabilities(client: TestClient) -> None:
     body = client.get(API_PREFIX).json()
 
     assert set(body["capabilities"]) == set(CAPABILITIES)
 
 
-def test_discovery_capability_set_matches_endpoint_set() -> None:
+def test_discovery_capability_set_matches_endpoint_set(client: TestClient) -> None:
     body = client.get(API_PREFIX).json()
 
     assert set(body["capabilities"]) == set(body["endpoints"]), (
@@ -30,14 +28,14 @@ def test_discovery_capability_set_matches_endpoint_set() -> None:
     )
 
 
-def test_discovery_endpoint_paths_share_api_prefix() -> None:
+def test_discovery_endpoint_paths_share_api_prefix(client: TestClient) -> None:
     endpoints = client.get(API_PREFIX).json()["endpoints"]
 
     for capability, path in endpoints.items():
         assert path == f"{API_PREFIX}/{capability}"
 
 
-def test_discovery_response_is_published_in_openapi_schema() -> None:
+def test_discovery_response_is_published_in_openapi_schema(client: TestClient) -> None:
     schema = client.get("/openapi.json").json()
 
     assert "DiscoveryResponse" in schema["components"]["schemas"], (

--- a/tests/test_healthz.py
+++ b/tests/test_healthz.py
@@ -1,0 +1,25 @@
+from fastapi.testclient import TestClient
+
+from bahai_api.main import API_PREFIX
+
+
+def test_healthz_returns_ok(client: TestClient) -> None:
+    response = client.get("/healthz")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_healthz_lives_outside_api_prefix(client: TestClient) -> None:
+    # Probes (compose, k8s, load balancers) should not chase wire-protocol
+    # version bumps when API_PREFIX changes.
+    assert not "/healthz".startswith(API_PREFIX)
+
+
+def test_healthz_response_is_published_in_openapi_schema(client: TestClient) -> None:
+    schema = client.get("/openapi.json").json()
+
+    assert "HealthResponse" in schema["components"]["schemas"], (
+        "healthz must publish a typed schema so probes and clients can rely on the response shape"
+    )
+    assert "/healthz" in schema["paths"]


### PR DESCRIPTION
Closes #17 and #18.

## Summary

- **#18**: Move `TestClient(app)` into a shared `client` fixture in `tests/conftest.py`; refactor `test_discovery.py` to consume it; document the convention in `CLAUDE.md`.
- **#17**: Add `GET /healthz` returning `{"status": "ok"}` via a typed `HealthResponse` Pydantic model. Mounted outside `API_PREFIX` so probes don't track wire-protocol bumps. New `tests/test_healthz.py` covers status code, body shape, and OpenAPI schema publication.

Bundled because #18 says "pick up when adding the second test module" — and `test_healthz.py` is exactly that.

Two commits, one per issue, for readability.

## Test plan

- [x] `just check` clean (ruff + format + pyright)
- [x] `just test` green (8 tests)
- [x] `curl localhost:8000/healthz` returns 200 with `{"status": "ok"}`
- [x] `HealthResponse` and `/healthz` published in `openapi.json`
- [x] Existing discovery tests still green via the new fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)